### PR TITLE
Migrated to Azure.Storage.Queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Homely - Storage Queues library.
 
-[![Build Status](https://dev.azure.com/homelyau/Homely.Storage.Queues/_apis/build/status/Homely.Homely.Storage.Queues?branchName=master)](https://dev.azure.com/homelyau/Homely.Storage.Queues/_build/latest?definitionId=7&branchName=master)
+[![Build Status](https://dev.azure.com/homelyau/Homely.Storage.Queues/_apis/build/status/Homely.Homely.Storage.Queues?branchName=refs%2Fpull%2F5%2Fmerge)](https://dev.azure.com/homelyau/Homely.Storage.Queues/_build/latest?definitionId=7&branchName=refs%2Fpull%2F5%2Fmerge)
+[![codecov](https://codecov.io/gh/Homely/Homely.Storage.Queues/branch/master/graph/badge.svg?token=jalOqmprkb)](https://codecov.io/gh/Homely/Homely.Storage.Queues)
 
 This library contains some helpers when working with Queue Storage.  
 A common pattern when working with queues is to serialize/deserialize complex objects to be stored in a queue message. This library helps simplify this process - both ways. The content of the queue needs to be a string, so any value is converted either into a string representation (when a 'simple' type) -or- a string-JSON representation (when a 'complex' type).

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,7 @@ steps:
 - task: PowerShell@2
   inputs:
     targetType: 'inline'
-    script: 'bash codecov.sh -s $(Agent.BuildDirectory) -f "*coverage.cobertura.xml" -Z -t $(CODECOV_TOKEN)'
+    script: 'bash codecov.sh -s $(Agent.BuildDirectory) -f "*coverage.cobertura.xml" -Z -t $($env:CODECOV_TOKEN)'
     pwsh: true
   displayName: 'codecov: upload'
     

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,12 +45,22 @@ steps:
     projects: '$(solutionFile)'
     arguments: '--configuration $(buildConfiguration) --no-restore -p:Version=$(assemblyVersion) -p:langversion=latest'
 
-- task: DotNetCoreCLI@2
+- script: dotnet test -c $(buildConfiguration) -v minimal --no-build --logger trx --collect:"XPlat Code Coverage" --results-directory './CodeCoverageResults'
+  displayName: 'dotnet test'
+  
+- task: PowerShell@2
   inputs:
-    command: test
-    projects: '**/tests/*/*.csproj'
-    arguments: '--configuration $(buildConfiguration) -p:Version=$(assemblyVersion) --no-build'
-  displayName: 'dotnet test'  
+    targetType: 'inline'
+    script: 'Invoke-WebRequest -Uri "https://codecov.io/bash" -OutFile codecov.sh'
+    pwsh: true
+  displayName: 'codecov: download script'
+
+- task: PowerShell@2
+  inputs:
+    targetType: 'inline'
+    script: 'bash codecov.sh -s $(Agent.BuildDirectory) -f "*coverage.cobertura.xml" -Z -t $(CODECOV_TOKEN)'
+    pwsh: true
+  displayName: 'codecov: upload'
     
 - script: dotnet pack --configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory) -p:Version=$(assemblyVersion) -v normal --no-build
   displayName: 'dotnet pack [i.e. create nuget package]'

--- a/src/Homely.Storage.Queues/AzureMessage.cs
+++ b/src/Homely.Storage.Queues/AzureMessage.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.WindowsAzure.Storage.Queue;
+using Azure.Storage.Queues.Models;
 
 namespace Homely.Storage.Queues
 {
@@ -8,7 +8,10 @@ namespace Homely.Storage.Queues
     /// <remarks>The <code>Model</code> is a specific type, provided.</remarks>
     public class AzureMessage : Message
     {
-        public AzureMessage(CloudQueueMessage message) : base(message.AsString, message.Id, message.PopReceipt, message.DequeueCount)
+        public AzureMessage(QueueMessage message) : base(message.Body.ToString(),
+                                                         message.MessageId,
+                                                         message.PopReceipt,
+                                                         message.DequeueCount)
         {
         }
     }
@@ -19,7 +22,10 @@ namespace Homely.Storage.Queues
     /// <remarks>The <code>Model</code> is a specific type, provided.</remarks>
     public class AzureMessage<T> : Message<T>
     {
-        public AzureMessage(T model, CloudQueueMessage message) : base(model, message.Id, message.PopReceipt, message.DequeueCount)
+        public AzureMessage(T model, QueueMessage message) : base(model,
+                                                                  message.MessageId,
+                                                                  message.PopReceipt,
+                                                                  message.DequeueCount)
         {
         }
     }

--- a/src/Homely.Storage.Queues/AzureQueue.cs
+++ b/src/Homely.Storage.Queues/AzureQueue.cs
@@ -218,13 +218,12 @@ namespace Homely.Storage.Queues
             return messages.Select(message => new AzureMessage(message));
         }
 
-
         private async Task<QueueMessage> ReceiveMessageAsync(TimeSpan? visibilityTimeout = null, CancellationToken cancellationToken = default)
         {
             var messages = await ReceiveMessagesAsync(1,
                                                       visibilityTimeout,
                                                       cancellationToken);
-            return messages.SingleOrDefault();
+            return messages.FirstOrDefault();
         }
 
         private async Task<QueueMessage[]> ReceiveMessagesAsync(int messageCount,

--- a/src/Homely.Storage.Queues/AzureQueue.cs
+++ b/src/Homely.Storage.Queues/AzureQueue.cs
@@ -1,8 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Queue;
+using Azure.Storage.Queues;
+using Azure.Storage.Queues.Models;
+using Microsoft.Extensions.Logging;
 using MoreLinq;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,7 +14,7 @@ namespace Homely.Storage.Queues
     {
         private readonly ILogger<AzureQueue> _logger;
         private readonly string _connectionString;
-        private Lazy<Task<CloudQueue>> _queue;
+        private Lazy<Task<QueueClient>> _queue;
 
         public string Name { get; }
 
@@ -37,10 +36,10 @@ namespace Homely.Storage.Queues
             Name = queueName;
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-            _queue = new Lazy<Task<CloudQueue>>(CreateCloudQueue);
+            _queue = new Lazy<Task<QueueClient>>(CreateCloudQueue);
         }
 
-        protected Task<CloudQueue> Queue
+        protected Task<QueueClient> Queue
         {
             get
             {
@@ -48,25 +47,15 @@ namespace Homely.Storage.Queues
             }
             set
             {
-                _queue = new Lazy<Task<CloudQueue>>(() => value);
+                _queue = new Lazy<Task<QueueClient>>(() => value);
             }
         }
 
-        private async Task<CloudQueue> CreateCloudQueue()
+        private async Task<QueueClient> CreateCloudQueue()
         {
-            // TODO: Add POLLY retrying.
-
-            if (!CloudStorageAccount.TryParse(_connectionString, out CloudStorageAccount storageAccount))
-            {
-                _logger.LogError($"Failed to create an Azure Storage Account for the provided credentials. Check the connection string in the your configuration (appsettings or environment variables, etc).");
-                throw new Exception("Failed to create an Azure Storage Account.");
-            }
-
-            var cloudQueueClient = storageAccount.CreateCloudQueueClient();
-            var cloudQueue = cloudQueueClient.GetQueueReference(Name);
-
-            var created = await cloudQueue.CreateIfNotExistsAsync();
-            if (created)
+            var queue = new QueueClient(_connectionString, Name);
+            var createIfNotExistsResponse = await queue.CreateIfNotExistsAsync();
+            if (createIfNotExistsResponse != null)
             {
                 _logger.LogInformation("  - No Azure Queue [{queueName}] found - so one was auto created.", Name);
             }
@@ -75,12 +64,13 @@ namespace Homely.Storage.Queues
                 _logger.LogInformation("  - Using existing Azure Queue [{queueName}].", Name);
             }
 
-            return cloudQueue;
+            return queue;
         }
 
         /// <inheritdoc />
         public async Task AddMessageAsync<T>(T item,
-                                             TimeSpan? initialVisibilityDelay = null,
+                                             TimeSpan? visibilityTimeout = null,
+                                             TimeSpan? timeToLive = null,
                                              CancellationToken cancellationToken = default)
         {
             if (item == null)
@@ -88,33 +78,28 @@ namespace Homely.Storage.Queues
                 throw new ArgumentNullException(nameof(item));
             }
 
-            CloudQueueMessage message;
-
-            // Don't waste effort serializing a string. It's already in a format that's ready to go.
-            if (Helpers.IsASimpleType(typeof(T)))
-            {
-                message = new CloudQueueMessage(item.ToString());
-            }
-            else
-            {
-                // It's a complex type, so serialize this as Json.
-                var messageContent = JsonConvert.SerializeObject(item);
-                message = new CloudQueueMessage(messageContent);
-            }
-
             var queue = await Queue;
 
-            await queue.AddMessageAsync(message,
-                                        null,
-                                        initialVisibilityDelay,
-                                        null,
-                                        null,
-                                        cancellationToken);
+            if (Helpers.IsASimpleType(typeof(T))) // Don't waste effort serializing a string. It's already in a format that's ready to go.
+            {
+                await queue.SendMessageAsync(item.ToString(),
+                                             visibilityTimeout,
+                                             timeToLive,
+                                             cancellationToken);
+            }
+            else // It's a complex type, so serialize this as Json.
+            {
+                await queue.SendMessageAsync(BinaryData.FromObjectAsJson(item),
+                                             visibilityTimeout,
+                                             timeToLive,
+                                             cancellationToken);
+            }
         }
 
         /// <inheritdoc />
         public async Task AddMessagesAsync<T>(IEnumerable<T> contents,
                                               TimeSpan? initialVisibilityDelay = null,
+                                              TimeSpan? timeToLive = null,
                                               int batchSize = 25,
                                               CancellationToken cancellationToken = default)
         {
@@ -136,7 +121,10 @@ namespace Homely.Storage.Queues
 
             foreach (var batch in contents.Batch(finalBatchSize))
             {
-                var tasks = batch.Select(content => AddMessageAsync(content, initialVisibilityDelay, cancellationToken));
+                var tasks = batch.Select(content => AddMessageAsync(content,
+                                                                    initialVisibilityDelay,
+                                                                    timeToLive,
+                                                                    cancellationToken));
 
                 // Execute this batch.
                 await Task.WhenAll(tasks);
@@ -170,24 +158,13 @@ namespace Homely.Storage.Queues
         }
 
         /// <inheritdoc  />
-        public async Task<Message<T>> GetMessageAsync<T>(TimeSpan? visibilityTimeout = null,
-                                                         CancellationToken cancellationToken = default)
+        public async Task<Message<T>> GetMessageAsync<T>(TimeSpan? visibilityTimeout = null, CancellationToken cancellationToken = default)
         {
-            var queue = await Queue;
-
-            var message = await queue.GetMessageAsync(visibilityTimeout,
-                                                      null,
-                                                      null,
-                                                      cancellationToken);
-
-            if (message == null)
-            {
-                return null;
-            }
+            var message = await ReceiveMessageAsync(visibilityTimeout, cancellationToken);
 
             if (Helpers.IsASimpleType(typeof(T)))
             {
-                var value = (T)Convert.ChangeType(message.AsString, typeof(T));
+                var value = (T)Convert.ChangeType(message.Body, typeof(T));
                 return new AzureMessage<T>(value, message);
             }
 
@@ -196,14 +173,10 @@ namespace Homely.Storage.Queues
         }
 
         /// <inheritdoc  />
-        public async Task<Message> GetMessageAsync(TimeSpan? visibilityTimeout = null,
-                                                   CancellationToken cancellationToken = default)
+        public async Task<Message> GetMessageAsync(TimeSpan? visibilityTimeout = null, CancellationToken cancellationToken = default)
         {
-            var queue = await Queue;
-            var message = await queue.GetMessageAsync(visibilityTimeout,
-                                                      null,
-                                                      null,
-                                                      cancellationToken);
+            var message = await ReceiveMessageAsync(visibilityTimeout, cancellationToken);
+
             return message == null
                 ? null
                 : new AzureMessage(message);
@@ -220,13 +193,11 @@ namespace Homely.Storage.Queues
             }
 
             var queue = await Queue;
-            var messages = await queue.GetMessagesAsync(messageCount,
-                                                        visibilityTimeout,
-                                                        null,
-                                                        null,
-                                                        cancellationToken);
+            var messages = await ReceiveMessagesAsync(messageCount,
+                                                      visibilityTimeout,
+                                                      cancellationToken);
 
-            return messages?.Select(message => message.DeserializeMessage<T>()) ?? Enumerable.Empty<Message<T>>();
+            return messages.Select(message => message.DeserializeMessage<T>());
         }
 
         /// <inheritdoc  />
@@ -240,21 +211,45 @@ namespace Homely.Storage.Queues
             }
 
             var queue = await Queue;
-            var messages = await queue.GetMessagesAsync(messageCount,
-                                                        visibilityTimeout,
-                                                        null,
-                                                        null,
-                                                        cancellationToken);
+            var messages = await ReceiveMessagesAsync(messageCount,
+                                                      visibilityTimeout,
+                                                      cancellationToken);
 
-            return messages?.Select(message => new AzureMessage(message)) ?? Enumerable.Empty<Message>();
+            return messages.Select(message => new AzureMessage(message));
+        }
+
+
+        private async Task<QueueMessage> ReceiveMessageAsync(TimeSpan? visibilityTimeout = null, CancellationToken cancellationToken = default)
+        {
+            var messages = await ReceiveMessagesAsync(1,
+                                                      visibilityTimeout,
+                                                      cancellationToken);
+            return messages.SingleOrDefault();
+        }
+
+        private async Task<QueueMessage[]> ReceiveMessagesAsync(int messageCount,
+                                                              TimeSpan? visibilityTimeout = null,
+                                                              CancellationToken cancellationToken = default)
+        {
+            var queue = await Queue;
+            var receiveMessagesResponse = await queue.ReceiveMessagesAsync(messageCount,
+                                                                           visibilityTimeout,
+                                                                           cancellationToken);
+            return receiveMessagesResponse == null ||
+                   receiveMessagesResponse.Value == null
+                ? Array.Empty<QueueMessage>()
+                : receiveMessagesResponse.Value;
         }
 
         /// <inheritdoc  />
         public async Task<int> GetMessageCountAsync(CancellationToken cancellationToken = default)
         {
             var queue = await Queue;
-            await queue.FetchAttributesAsync(cancellationToken);
-            return queue.ApproximateMessageCount ?? 0;
+            var queueProperties = await queue.GetPropertiesAsync(cancellationToken);
+            return queueProperties == null ||
+                   queueProperties.Value == null
+                ? 0
+                : queueProperties.Value.ApproximateMessagesCount;
         }
     }
 }

--- a/src/Homely.Storage.Queues/AzureQueue.cs
+++ b/src/Homely.Storage.Queues/AzureQueue.cs
@@ -227,8 +227,8 @@ namespace Homely.Storage.Queues
         }
 
         private async Task<QueueMessage[]> ReceiveMessagesAsync(int messageCount,
-                                                              TimeSpan? visibilityTimeout = null,
-                                                              CancellationToken cancellationToken = default)
+                                                                TimeSpan? visibilityTimeout = null,
+                                                                CancellationToken cancellationToken = default)
         {
             var queue = await Queue;
             var receiveMessagesResponse = await queue.ReceiveMessagesAsync(messageCount,

--- a/src/Homely.Storage.Queues/CloudQueueMessageExtensions.cs
+++ b/src/Homely.Storage.Queues/CloudQueueMessageExtensions.cs
@@ -2,8 +2,10 @@ using Azure.Storage.Queues.Models;
 using System;
 
 namespace Homely.Storage.Queues
-{    internal static class CloudQueueMessageExtensions
-    {        internal static Message<T> DeserializeMessage<T>(this QueueMessage message)
+{    
+    internal static class CloudQueueMessageExtensions
+    {        
+        internal static Message<T> DeserializeMessage<T>(this QueueMessage message)
         {
             if (message == null)
             {

--- a/src/Homely.Storage.Queues/CloudQueueMessageExtensions.cs
+++ b/src/Homely.Storage.Queues/CloudQueueMessageExtensions.cs
@@ -1,23 +1,20 @@
-﻿using Microsoft.WindowsAzure.Storage.Queue;
-using Newtonsoft.Json;
+using Azure.Storage.Queues.Models;
 using System;
 
 namespace Homely.Storage.Queues
-{
-    internal static class CloudQueueMessageExtensions
-    {
-        internal static Message<T> DeserializeMessage<T>(this CloudQueueMessage message)
+{    internal static class CloudQueueMessageExtensions
+    {        internal static Message<T> DeserializeMessage<T>(this QueueMessage message)
         {
             if (message == null)
             {
                 throw new ArgumentNullException(nameof(message));
             }
 
-            var model = JsonConvert.DeserializeObject<T>(message.AsString);
+            var model = message.Body.ToObjectFromJson<T>();
             return message.ToMessage(model);
         }
 
-        internal static Message<T> ToMessage<T>(this CloudQueueMessage message, T model)
+        internal static Message<T> ToMessage<T>(this QueueMessage message, T model)
         {
             if (message == null)
             {
@@ -30,7 +27,7 @@ namespace Homely.Storage.Queues
             }
 
             return new Message<T>(model, 
-                                  message.Id, 
+                                  message.MessageId,
                                   message.PopReceipt, 
                                   message.DequeueCount);
         }

--- a/src/Homely.Storage.Queues/Helpers.cs
+++ b/src/Homely.Storage.Queues/Helpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Homely.Storage.Queues
 {
@@ -12,7 +12,7 @@ namespace Homely.Storage.Queues
         /// <remarks>To see the full list of .NET Primitive types: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/built-in-types-table</remarks>
         /// <returns>True if this is a Simple Type or False if it is not.</returns>
         public static bool IsASimpleType(this Type type) => type.IsPrimitive ||
-                                                              type == typeof(string) ||
-                                                              type == typeof(decimal);
+                                                            type == typeof(string) ||
+                                                            type == typeof(decimal);
     }
 }

--- a/src/Homely.Storage.Queues/Homely.Storage.Queues.csproj
+++ b/src/Homely.Storage.Queues/Homely.Storage.Queues.csproj
@@ -26,15 +26,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="3.0.3" />
-    <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="9.4.2" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.6.0" />
+    <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="3.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="morelinq" Version="3.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="morelinq" Version="3.3.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Homely.Storage.Queues/IQueue.cs
+++ b/src/Homely.Storage.Queues/IQueue.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,12 +17,14 @@ namespace Homely.Storage.Queues
         /// </summary>
         /// <typeparam name="T">Type of item.</typeparam>
         /// <param name="item">An item to add to the queue.</param>
-        /// <param name="initialVisibilityDelay">How long to initially hide the message.</param>
+        /// <param name="visibilityTimeout">How long to initially hide the message.</param>
+        /// <param name="timeToLive">When the message should expire.</param>
         /// <param name="cancellationToken">A System.Threading.CancellationToken to observe while waiting for a task to complete.</param>
         /// <returns>A System.Threading.Tasks.Task object that represents the asynchronous operation.</returns>
         /// <remarks>If the item is a IsPrimitive (int, etc) or a string then it's stored -as is-. Otherwise, it is serialized to Json and then stored as Json.(</remarks>
         Task AddMessageAsync<T>(T item, 
-                                TimeSpan? initialVisibilityDelay = null, 
+                                TimeSpan? visibilityTimeout = null,
+                                TimeSpan? timeToLive = null,
                                 CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -30,13 +32,15 @@ namespace Homely.Storage.Queues
         /// </summary>
         /// <typeparam name="T">Type of item.</typeparam>
         /// <param name="contents">Collection of content to add to the queue.</param>
-        /// <param name="initialVisibilityDelay">How long to initially hide the message.</param>
+        /// <param name="visibilityTimeout">How long to initially hide the message.</param>
+        /// <param name="timeToLive">When the message should expire.</param>
         /// <param name="batchSize">Number of messages per batch, to store as one parallel execution.</param>
         /// <param name="cancellationToken">A System.Threading.CancellationToken to observe while waiting for a task to complete.</param>
         /// <returns>A System.Threading.Tasks.Task object that represents the asynchronous operation.</returns>
         /// <remarks>If any item is a IsPrimitive (int, etc) or a string then it's stored -as is-. Otherwise, it is serialized to Json and then stored as Json.(</remarks>
-        Task AddMessagesAsync<T>(IEnumerable<T> contents, 
-                                 TimeSpan? initialVisibilityDelay = null, 
+        Task AddMessagesAsync<T>(IEnumerable<T> contents,
+                                 TimeSpan? visibilityTimeout = null,
+                                 TimeSpan? timeToLive = null,
                                  int batchSize = 25, 
                                  CancellationToken cancellationToken = default);
 
@@ -58,7 +62,7 @@ namespace Homely.Storage.Queues
         /// <param name="cancellationToken">A System.Threading.CancellationToken to observe while waiting for a task to complete.</param>
         /// <returns>A System.Threading.Tasks.Task object that represents the asynchronous operation.</returns>
         /// <remarks>The content of the message will attempt to be deserialized from Json. If the message is a Primitive type or a string, then the Json deserialization will be still run but no error should occur.</remarks>
-        Task<Message> GetMessageAsync(TimeSpan? visibilityTimeout = null, 
+        Task<Message> GetMessageAsync(TimeSpan? visibilityTimeout = null,
                                       CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/src/Homely.Storage.Queues/Message.cs
+++ b/src/Homely.Storage.Queues/Message.cs
@@ -1,4 +1,3 @@
-﻿using Microsoft.WindowsAzure.Storage.Queue;
 using System;
 
 namespace Homely.Storage.Queues
@@ -12,7 +11,10 @@ namespace Homely.Storage.Queues
         public Message(string content,
                        string id,
                        string receipt,
-                       int dequeueCount) : base(content, id, receipt, dequeueCount)
+                       long dequeueCount) : base(content,
+                                                 id,
+                                                 receipt,
+                                                 dequeueCount)
         { }
     }
 
@@ -25,7 +27,7 @@ namespace Homely.Storage.Queues
         public Message(T model,
                        string id,
                        string receipt,
-                       int dequeueCount)
+                       long dequeueCount)
         {
             if (model == null)
             {
@@ -52,12 +54,9 @@ namespace Homely.Storage.Queues
             Receipt = receipt;
             DequeueCount = dequeueCount;
         }
-
-        public string Id { get; }   
+        public string Id { get; }
         public string Receipt { get; }
-
-        public int DequeueCount { get; }
-
+        public long DequeueCount { get; }
         public T Model { get; }
     }
 }

--- a/tests/Homely.Storage.Queues.Tests/DeleteMessageAsyncTests.cs
+++ b/tests/Homely.Storage.Queues.Tests/DeleteMessageAsyncTests.cs
@@ -1,4 +1,5 @@
-﻿using Moq;
+using Azure;
+using Moq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -15,13 +16,20 @@ namespace Homely.Storage.Queues.Tests
             const string id = "1234";
             const string receiptId = "asdasd";
             const int dequeueCount = 5;
-            var message = new Message(content, id, receiptId, dequeueCount);
+            var message = new Message(content,
+                                      id,
+                                      receiptId,
+                                      dequeueCount);
+            QueueClient.Setup(x => x.DeleteMessageAsync(id,
+                                                        receiptId,
+                                                        It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(new Mock<Response>().Object);
 
             // Act.
             await Queue.DeleteMessageAsync(message);
 
             // Assert.
-            CloudQueue.Verify(x => x.DeleteMessageAsync(id, receiptId, It.IsAny<CancellationToken>()), Times.Once);
+            QueueClient.VerifyAll();
         }
 
         [Fact]
@@ -36,13 +44,20 @@ namespace Homely.Storage.Queues.Tests
             const string id = "1234";
             const string receiptId = "asdasd";
             const int dequeueCount = 5;
-            var message = new Message<FakeThing>(fakeThing, id, receiptId, dequeueCount);
+            var message = new Message<FakeThing>(fakeThing,
+                                                 id,
+                                                 receiptId,
+                                                 dequeueCount);
+            QueueClient.Setup(x => x.DeleteMessageAsync(id,
+                                                        receiptId,
+                                                        It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(new Mock<Response>().Object);
 
             // Act.
             await Queue.DeleteMessageAsync(message);
 
             // Assert.
-            CloudQueue.Verify(x => x.DeleteMessageAsync(id, receiptId, It.IsAny<CancellationToken>()), Times.Once);
+            QueueClient.VerifyAll();
         }
     }
 }

--- a/tests/Homely.Storage.Queues.Tests/FakeAzureStorageQueue.cs
+++ b/tests/Homely.Storage.Queues.Tests/FakeAzureStorageQueue.cs
@@ -1,12 +1,12 @@
-﻿using Microsoft.Extensions.Logging;
-using Microsoft.WindowsAzure.Storage.Queue;
+using Azure.Storage.Queues;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
 namespace Homely.Storage.Queues.Tests
 {
     public class FakeAzureStorageQueue : AzureQueue
     {
-        public FakeAzureStorageQueue(CloudQueue cloudQueue,
+        public FakeAzureStorageQueue(QueueClient cloudQueue,
                                      ILogger<FakeAzureStorageQueue> logger) : base("ignored-connection-string", "ignored-name", logger)
         {
             Queue = Task.FromResult(cloudQueue);

--- a/tests/Homely.Storage.Queues.Tests/FakeAzureStorageQueueCommonTestSetup.cs
+++ b/tests/Homely.Storage.Queues.Tests/FakeAzureStorageQueueCommonTestSetup.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.Extensions.Logging;
-using Microsoft.WindowsAzure.Storage.Queue;
+using Azure.Storage.Queues;
+using Azure.Storage.Queues.Models;
+using Microsoft.Extensions.Logging;
 using Moq;
-using Newtonsoft.Json;
-using System;
+using System.Text.Json;
 
 namespace Homely.Storage.Queues.Tests
 {
@@ -10,28 +10,28 @@ namespace Homely.Storage.Queues.Tests
     {
         protected FakeAzureStorageQueueCommonTestSetup()
         {
-            CloudQueue = new Mock<CloudQueue>(new Uri("http://a.b.c.d"));
+            QueueClient = new Mock<QueueClient>(MockBehavior.Strict);
             Logger = new Mock<ILogger<FakeAzureStorageQueue>>();
-            Queue = new FakeAzureStorageQueue(CloudQueue.Object, Logger.Object);
+            Queue = new FakeAzureStorageQueue(QueueClient.Object, Logger.Object);
         }
 
-        protected Mock<CloudQueue> CloudQueue { get; }
+        protected Mock<QueueClient> QueueClient { get; }
         protected Mock<ILogger<FakeAzureStorageQueue>> Logger { get; }
         protected FakeAzureStorageQueue Queue { get; }
 
-        protected CloudQueueMessage CreateMessage<T>(T someObject)
+        protected QueueMessage CreateMessage<T>(T someObject)
         {
             const string id = "aaa";
             const string popReceipt = "bbb";
 
-            var content = Helpers.IsASimpleType(typeof(T))
+            var messageText = Helpers.IsASimpleType(typeof(T))
                     ? someObject.ToString()
-                    : JsonConvert.SerializeObject(someObject);
+                    : JsonSerializer.Serialize(someObject);
 
-            var message = new CloudQueueMessage(id, popReceipt);
-            message.SetMessageContent2(System.Text.Encoding.UTF8.GetBytes(content));
-
-            return message;
+            return QueuesModelFactory.QueueMessage(id,
+                                                   popReceipt,
+                                                   messageText,
+                                                   0);
         }
     }
 }

--- a/tests/Homely.Storage.Queues.Tests/FakeThing.cs
+++ b/tests/Homely.Storage.Queues.Tests/FakeThing.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Homely.Storage.Queues.Tests
 {
@@ -7,6 +7,5 @@ namespace Homely.Storage.Queues.Tests
         public int Id { get; set; }
         public string Name { get; set; }
         public IEnumerable<string> NickNames { get; set; }
-
     }
 }

--- a/tests/Homely.Storage.Queues.Tests/GetMessageCountAsyncTests.cs
+++ b/tests/Homely.Storage.Queues.Tests/GetMessageCountAsyncTests.cs
@@ -1,0 +1,36 @@
+using Azure;
+using Azure.Storage.Queues.Models;
+using Moq;
+using Shouldly;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Homely.Storage.Queues.Tests
+{
+    public class GetMessageCountAsyncTests : FakeAzureStorageQueueCommonTestSetup
+    {
+        [Fact]
+        public async Task GivenAQueue_GetMessageCountAsync_ReturnsMessageCount()
+        {
+            // Arrange.
+            var messageCount = 100;
+            var queueProperties = QueuesModelFactory.QueueProperties(new Dictionary<string, string>(), messageCount);
+            var queuePropertiesResponse = new Mock<Response<QueueProperties>>(MockBehavior.Strict);
+            queuePropertiesResponse.Setup(x => x.Value)
+                                   .Returns(queueProperties);
+
+            QueueClient.Setup(x => x.GetPropertiesAsync(It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(queuePropertiesResponse.Object);
+
+            // Act.
+            var actualMessageCount = await Queue.GetMessageCountAsync();
+
+            // Assert.
+            actualMessageCount.ShouldBe(messageCount);
+
+            QueueClient.VerifyAll();
+        }
+    }
+}

--- a/tests/Homely.Storage.Queues.Tests/GetMessagesAsyncTests.cs
+++ b/tests/Homely.Storage.Queues.Tests/GetMessagesAsyncTests.cs
@@ -1,0 +1,130 @@
+using Azure;
+using Azure.Storage.Queues.Models;
+using Moq;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Homely.Storage.Queues.Tests
+{
+    public class GetMessagesAsyncTests : FakeAzureStorageQueueCommonTestSetup
+    {
+        public static TheoryData<string[]> ValidStrings => new TheoryData<string[]>
+        {
+            {
+                new[] {"1", "2", "3"}
+            },
+            {
+                new[] {"1.1", "2.2", "3.3"}
+            },
+            {
+                new[] {"hi there", "how are", "you today"}
+            },
+            {
+                new[] { Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
+            },
+            {
+                new[] { "[1,2,3]", "[4,5,6]", "[7,8,9]" }
+            }
+        };
+
+        public static TheoryData<object[]> ValidComplexObjects => new TheoryData<object[]>
+        {
+            {
+                new[]
+                {
+                    new FakeThing
+                    {
+                        Id = 1,
+                        Name = "name",
+                        NickNames = new[]
+                        {
+                            "name-1",
+                            "name-2"
+                        }
+                    },
+                    new FakeThing
+                    {
+                        Id = 2,
+                        Name = "name-2",
+                        NickNames = new[]
+                        {
+                            "name-3",
+                            "name-4"
+                        }
+                    }
+                }
+            },
+            {
+                new[]
+                {
+                    Enumerable.Range(1, 5).ToList(),
+                    Enumerable.Range(1, 5).ToList()
+                }
+            }
+        };
+
+        [Theory]
+        [MemberData(nameof(ValidStrings))]
+        public async Task GivenSomeQueueMessagesWithSomeStringContent_GetMessagesAsync_ReturnsMessages(string[] contents)
+        {
+            // Arrange.
+            SetupQueue(contents);
+
+            // Act.
+            var result = await Queue.GetMessagesAsync(contents.Length);
+
+            // Assert.
+            result.ShouldNotBeNull();
+            result.Select(r => r.Model)
+                  .SequenceEqual(contents)
+                  .ShouldBeTrue();
+
+            QueueClient.VerifyAll();
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidComplexObjects))]
+        public async Task GivenAQueueMessageWithSomeJsonContent_GetMessagesAsync_ReturnsAMessage<T>(T[] someObjects)
+        {
+            // Arrange.
+            SetupQueue(someObjects);
+            var expected = someObjects.Select(obj => JsonSerializer.Serialize(obj));
+
+            // Act.
+            var result = await Queue.GetMessagesAsync<T>(someObjects.Length);
+
+            // Assert.
+            result.ShouldNotBeNull();
+            result.Select(r => JsonSerializer.Serialize(r.Model))
+                  .SequenceEqual(expected)
+                  .ShouldBeTrue();
+
+            QueueClient.VerifyAll();
+        }
+
+        private void SetupQueue<T>(T[] someObjectsOrStrings)
+        {
+            var messages = new List<QueueMessage>();
+
+            foreach (var objectOrString in someObjectsOrStrings)
+            {
+                messages.Add(CreateMessage(objectOrString));
+            }
+
+            var response = new Mock<Response<QueueMessage[]>>();
+            response.Setup(x => x.Value)
+                    .Returns(messages.ToArray());
+
+            QueueClient.Setup(x => x.ReceiveMessagesAsync(It.IsAny<int>(),
+                                                          null,
+                                                          It.IsAny<CancellationToken>()))
+                      .ReturnsAsync(response.Object);
+        }
+    }
+}

--- a/tests/Homely.Storage.Queues.Tests/Homely.Storage.Queues.Tests.csproj
+++ b/tests/Homely.Storage.Queues.Tests/Homely.Storage.Queues.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Homely.Storage.Queues.Tests/Homely.Storage.Queues.Tests.csproj
+++ b/tests/Homely.Storage.Queues.Tests/Homely.Storage.Queues.Tests.csproj
@@ -7,13 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Homely.Testing" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Homely.Storage.Queues.Tests/Homely.Storage.Queues.Tests.csproj
+++ b/tests/Homely.Storage.Queues.Tests/Homely.Storage.Queues.Tests.csproj
@@ -15,6 +15,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Using System.Text.Json for serialisation, to match what underlying API uses (thus, no-longer Newtonsoft.Json dependency)
- Enhanced tests (added coverage, some were missing, migrated to .netcore3.1)

Fixes https://github.com/Homely/Homely.Storage.Queues/issues/4