### PR TITLE
Going back to Newtonsoft.Json :cry:

### DIFF
--- a/src/Homely.Storage.Queues/AzureQueue.cs
+++ b/src/Homely.Storage.Queues/AzureQueue.cs
@@ -2,6 +2,7 @@ using Azure.Storage.Queues;
 using Azure.Storage.Queues.Models;
 using Microsoft.Extensions.Logging;
 using MoreLinq;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -89,7 +90,7 @@ namespace Homely.Storage.Queues
             }
             else // It's a complex type, so serialize this as Json.
             {
-                await queue.SendMessageAsync(BinaryData.FromObjectAsJson(item),
+                await queue.SendMessageAsync(JsonConvert.SerializeObject(item),
                                              visibilityTimeout,
                                              timeToLive,
                                              cancellationToken);

--- a/src/Homely.Storage.Queues/CloudQueueMessageExtensions.cs
+++ b/src/Homely.Storage.Queues/CloudQueueMessageExtensions.cs
@@ -1,4 +1,5 @@
 using Azure.Storage.Queues.Models;
+using Newtonsoft.Json;
 using System;
 
 namespace Homely.Storage.Queues
@@ -12,7 +13,7 @@ namespace Homely.Storage.Queues
                 throw new ArgumentNullException(nameof(message));
             }
 
-            var model = message.Body.ToObjectFromJson<T>();
+            var model = JsonConvert.DeserializeObject<T>(message.Body.ToString());
             return message.ToMessage(model);
         }
 

--- a/tests/Homely.Storage.Queues.Tests/AddMessageAsyncTests.cs
+++ b/tests/Homely.Storage.Queues.Tests/AddMessageAsyncTests.cs
@@ -1,7 +1,6 @@
 using Azure;
 using Azure.Storage.Queues.Models;
 using Moq;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -65,7 +64,7 @@ namespace Homely.Storage.Queues.Tests
             else
             {
                 var messageContent = JsonSerializer.Serialize(content);
-                QueueClient.Setup(x => x.SendMessageAsync(It.Is<BinaryData>(bd => bd.ToString() == messageContent),
+                QueueClient.Setup(x => x.SendMessageAsync(It.Is<string>(str => str == messageContent),
                                                           null,
                                                           null,
                                                           It.IsAny<CancellationToken>()))

--- a/tests/Homely.Storage.Queues.Tests/AddMessagesAsyncTests.cs
+++ b/tests/Homely.Storage.Queues.Tests/AddMessagesAsyncTests.cs
@@ -1,7 +1,6 @@
 using Azure;
 using Azure.Storage.Queues.Models;
 using Moq;
-using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
@@ -86,7 +85,7 @@ namespace Homely.Storage.Queues.Tests
                     ? content.ToString()
                     : JsonSerializer.Serialize(content);
 
-                QueueClient.Setup(x => x.SendMessageAsync(It.Is<BinaryData>(bd => bd.ToString() == messageContent),
+                QueueClient.Setup(x => x.SendMessageAsync(It.Is<string>(str => str == messageContent),
                                                            null,
                                                            null,
                                                            It.IsAny<CancellationToken>()))


### PR DESCRIPTION
Azure Functions queue output bindings still uses Newtonsoft.Json, so we need to match that until they offer the flexibility of how messages are serialised.