### PR TITLE
Now decoding queue messages from base-64

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/Homely/Homely.Storage.Queues/branch/master/graph/badge.svg?token=jalOqmprkb)](https://codecov.io/gh/Homely/Homely.Storage.Queues)
 
 This library contains some helpers when working with Queue Storage.  
-A common pattern when working with queues is to serialize/deserialize complex objects to be stored in a queue message. This library helps simplify this process - both ways. The content of the queue needs to be a string, so any value is converted either into a string representation (when a 'simple' type) -or- a string-JSON representation (when a 'complex' type).
+A common pattern when working with queues is to serialize/deserialize complex objects to be stored in a queue message. This library helps simplify this process - both ways. The content of the queue needs to be a base-64 encoded string, so any value is converted either into a string representation (when a 'simple' type) -or- a string-JSON representation (when a 'complex' type).
 
 ### What's a Simple / Complex Type?
 - Simple: a [.NET Primitive](https://docs.microsoft.com/en-us/dotnet/api/system.type.isprimitive?view=netframework-4.7.2#remarks) or `string` or `decimal`

--- a/src/Homely.Storage.Queues/AzureMessage.cs
+++ b/src/Homely.Storage.Queues/AzureMessage.cs
@@ -8,7 +8,7 @@ namespace Homely.Storage.Queues
     /// <remarks>The <code>Model</code> is a specific type, provided.</remarks>
     public class AzureMessage : Message
     {
-        public AzureMessage(QueueMessage message) : base(message.Body.ToString(),
+        public AzureMessage(QueueMessage message) : base(message.Body.AsString(),
                                                          message.MessageId,
                                                          message.PopReceipt,
                                                          message.DequeueCount)

--- a/src/Homely.Storage.Queues/CloudQueueMessageExtensions.cs
+++ b/src/Homely.Storage.Queues/CloudQueueMessageExtensions.cs
@@ -13,7 +13,7 @@ namespace Homely.Storage.Queues
                 throw new ArgumentNullException(nameof(message));
             }
 
-            var model = JsonConvert.DeserializeObject<T>(message.Body.ToString());
+            var model = JsonConvert.DeserializeObject<T>(message.Body.AsString());
             return message.ToMessage(model);
         }
 
@@ -29,10 +29,7 @@ namespace Homely.Storage.Queues
                 throw new ArgumentNullException(nameof(model));
             }
 
-            return new Message<T>(model, 
-                                  message.MessageId,
-                                  message.PopReceipt, 
-                                  message.DequeueCount);
+            return new AzureMessage<T>(model, message);
         }
     }
 }

--- a/src/Homely.Storage.Queues/Helpers.cs
+++ b/src/Homely.Storage.Queues/Helpers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 
 namespace Homely.Storage.Queues
 {
@@ -14,5 +15,22 @@ namespace Homely.Storage.Queues
         public static bool IsASimpleType(this Type type) => type.IsPrimitive ||
                                                             type == typeof(string) ||
                                                             type == typeof(decimal);
+
+        /// <summary>
+        /// Returns a string representation of the BinaryData, decoding as base-64.
+        /// </summary>
+        /// <param name="binaryData">The data to decode</param>
+        /// <returns>Decoded string</returns>
+        /// <remarks>This method assumes messages are base-64 encoded.</remarks>
+        public static string AsString(this BinaryData binaryData)
+        {
+            if (binaryData is null)
+            {
+                throw new ArgumentNullException(nameof(binaryData));
+            }
+
+            var utf8Body = binaryData.ToString();
+            return Encoding.UTF8.GetString(Convert.FromBase64String(utf8Body));
+        }
     }
 }

--- a/tests/Homely.Storage.Queues.Tests/AsStringTests.cs
+++ b/tests/Homely.Storage.Queues.Tests/AsStringTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Text;
+using Newtonsoft.Json;
+using Shouldly;
+using Xunit;
+
+namespace Homely.Storage.Queues.Tests
+{
+    public class AsStringTests
+    {
+        private static FakeThing _fakeThing = new()
+        {
+            Id = 1,
+            Name = "Joe Bloggs",
+            NickNames = new[] { "joe", "bloggsy" }
+        };
+
+        public static TheoryData<BinaryData, string> Data => new TheoryData<BinaryData, string>
+        {
+            // string
+            {
+                BinaryData.FromString(Convert.ToBase64String(Encoding.UTF8.GetBytes(("AAAA")))),
+                "AAAA"
+            },
+
+            // Complex object
+            {
+                BinaryData.FromString(Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(_fakeThing)))),
+                "{\"Id\":1,\"Name\":\"Joe Bloggs\",\"NickNames\":[\"joe\",\"bloggsy\"]}"
+            },
+        };
+
+        [Theory]
+        [MemberData(nameof(Data))]
+        public void GivenSomeBinaryData_AsString_ReturnsString(BinaryData binaryData, string expectedString)
+        {
+            binaryData.AsString()
+                      .ShouldBe(expectedString);
+        }
+    }
+}

--- a/tests/Homely.Storage.Queues.Tests/FakeAzureStorageQueueCommonTestSetup.cs
+++ b/tests/Homely.Storage.Queues.Tests/FakeAzureStorageQueueCommonTestSetup.cs
@@ -2,6 +2,7 @@ using Azure.Storage.Queues;
 using Azure.Storage.Queues.Models;
 using Microsoft.Extensions.Logging;
 using Moq;
+using System;
 using System.Text.Json;
 
 namespace Homely.Storage.Queues.Tests
@@ -30,7 +31,7 @@ namespace Homely.Storage.Queues.Tests
 
             return QueuesModelFactory.QueueMessage(id,
                                                    popReceipt,
-                                                   messageText,
+                                                   Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(messageText)),
                                                    0);
         }
     }


### PR DESCRIPTION
New Azure SDK does not automatically decode base-64 messages, like previous ([reference](https://docs.microsoft.com/en-us/azure/storage/queues/storage-tutorial-queues?tabs=dotnet#dequeue-messages))